### PR TITLE
Update to use HTTPS links where possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@ width: auto;">
   <section class="footer-section" style="text-align:center;">
     <h6>Developed by Cuby & AroDev | Released under the MIT license | Absolutely no warranties</h6>
   </section>
-  <script src="https://code.jquery.com/jquery-latest.min.js?c=1" type="text/javascript"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   <script src='./dashboard/js/aro.js?c=1'></script>
   <script>
     var aro = new aro;

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@ width: auto;">
   <section class="footer-section" style="text-align:center;">
     <h6>Developed by Cuby & AroDev | Released under the MIT license | Absolutely no warranties</h6>
   </section>
-  <script src="http://code.jquery.com/jquery-latest.min.js?c=1" type="text/javascript"></script>
+  <script src="https://code.jquery.com/jquery-latest.min.js?c=1" type="text/javascript"></script>
   <script src='./dashboard/js/aro.js?c=1'></script>
   <script>
     var aro = new aro;

--- a/pages/login-add/index.html
+++ b/pages/login-add/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Login-Add - Arionum</title>
-  <link rel='stylesheet prefetch' href='http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css'>
+  <link rel='stylesheet prefetch' href='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css'>
   <link href="../../dashboard/modules/font-awesome-5/css/fontawesome-all.min.css" rel="stylesheet" media="all">
   <link rel="stylesheet" href="css/style.css">
 </head>
@@ -60,7 +60,7 @@
     <p>Authenticating...</p>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-  <script src='http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js'></script>
+  <script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js'></script>
   <script src='../../dashboard/js/aro.js'></script>
   <script>
     var aro = new aro;

--- a/pages/login/index.html
+++ b/pages/login/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Login - Arionum</title>
-  <link rel='stylesheet prefetch' href='http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css'>
+  <link rel='stylesheet prefetch' href='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css'>
   <link href="../../dashboard/modules/font-awesome-5/css/fontawesome-all.min.css" rel="stylesheet" media="all">
   <link rel="stylesheet" href="css/style.css">
 </head>
@@ -60,7 +60,7 @@
     <p>Authenticating...</p>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-  <script src='http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js'></script>
+  <script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js'></script>
   <script src='../../dashboard/js/aro.js'></script>
   <script>
     var aro = new aro;

--- a/pages/signup/index.html
+++ b/pages/signup/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Signup- Arionum</title>
-  <link rel='stylesheet prefetch' href='http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css'>
+  <link rel='stylesheet prefetch' href='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css'>
   <link href="../../dashboard/modules/font-awesome-5/css/fontawesome-all.min.css" rel="stylesheet" media="all">
   <link rel="stylesheet" href="css/style.css">
 </head>
@@ -60,7 +60,7 @@
     <p>Generating...</p>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-  <script src='http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js'></script>
+  <script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js'></script>
   <script src='../../dashboard/js/aro.js'></script>
   <script>
     var aro = new aro;


### PR DESCRIPTION
This also updates jQuery from `v1.11.1` to `v3.3.1` on the index page and enforces SRI (49e2bc461541949a49db180dc49856b48cdcb05f).